### PR TITLE
fix: More page titles are incorrect so they show up in search incorrectly

### DIFF
--- a/content/docs/dumaos-4/adblocker.md
+++ b/content/docs/dumaos-4/adblocker.md
@@ -1,4 +1,6 @@
-# Adblocker on DumaOS 4
+---
+title: Adblocker on DumaOS 4
+---
 
 Adblocker protects your devices by blocking ads and trackers network-wide: even on hard-to-protect devices such as Smart TVs and games consoles.
 

--- a/content/docs/telstra-game-optimiser/adblocker.md
+++ b/content/docs/telstra-game-optimiser/adblocker.md
@@ -1,4 +1,6 @@
-# Adblocker on Telstra Game Optimiser
+---
+title: Adblocker on Telstra Game Optimiser
+---
 
 Adblocker will block Ads, Tracking and Malware on all devices on your network. You can select which devices are filtered and which are not. You can also customize the blacklists to block specific websites.
 


### PR DESCRIPTION
I missed two titles in my previous commit. Specifically the "Adblocker" pages. I have fixed those here.