### PR TITLE
Removed mention of "live support" on contact page

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -11,6 +11,8 @@ Send your query via email: [netduma@netduma.com](mailto:netduma@netduma.com)
 
 We do not have a phone number for technical support. We recommend using the forums for the quickest response. There are lots of real people on the Netduma forums, including our support team. You're sure to get a quick and sentient response if you post there!
 
-Try our Facebook page if you want the highest change of chatting to somebody live: [Facebook](https://www.facebook.com/Netduma/)
+Also, check out our social media profiles:
+[Facebook](https://www.facebook.com/Netduma/)
+[X (Twitter)](https://x.com/netduma)
 
 We respond to emails and forum posts daily.


### PR DESCRIPTION
The support team informed me that we do not offer "live support", so I removed mention of it on the Contact page. I also added a link to our Twitter.