### PR TITLE
fix: Make Ping Optimiser error link work again in DumaWeb

### DIFF
--- a/content/frequently-asked-questions/legacyfaqs/ping-optimiser-encoutered-problem.md
+++ b/content/frequently-asked-questions/legacyfaqs/ping-optimiser-encoutered-problem.md
@@ -1,5 +1,7 @@
 ---
-title: DumaOS 3 - "Ping Optimiser has encountered a problem"
+title: Ping Optimiser has encountered a problem
+aliases:
+    - /support/solutions/articles/16000129545
 ---
 
 ## Why am I seeing this?


### PR DESCRIPTION
Add a redirect directly into the knowledge base instead of Cloudflare